### PR TITLE
Potential fix for code scanning alert no. 8: Incorrect conversion between integer types

### DIFF
--- a/chapter06/lib/msgqueue/kafka/listener.go
+++ b/chapter06/lib/msgqueue/kafka/listener.go
@@ -33,7 +33,7 @@ func NewKafkaEventListenerFromEnvironment() (msgqueue.EventListener, error) {
 		partitions = make([]int32, len(partitionStrings))
 
 		for i := range partitionStrings {
-			partition, err := strconv.Atoi(partitionStrings[i])
+			partition, err := strconv.ParseInt(partitionStrings[i], 10, 32)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Cloud-Native-Programming-with-Golang/security/code-scanning/8](https://github.com/ibiscum/Cloud-Native-Programming-with-Golang/security/code-scanning/8)

In general, to fix this kind of problem you should either (a) parse directly into a type with the correct bit size using `strconv.ParseInt`/`ParseUint` and then cast to the corresponding Go type, or (b) if you must parse into a wider type, add explicit upper/lower bound checks before converting to a smaller type.

For this specific code in `chapter06/lib/msgqueue/kafka/listener.go`, the best low‑impact fix is to stop using `strconv.Atoi` (which returns an `int`) and instead use `strconv.ParseInt` with a bit size of 32. That way, the parsing step itself enforces the `int32` range; the subsequent cast `int32(partition)` becomes safe by construction. Concretely:

- Change `partition, err := strconv.Atoi(partitionStrings[i])` to use `strconv.ParseInt(partitionStrings[i], 10, 32)`. Store the result in an `int64` (as returned by `ParseInt`).
- Then change `partitions[i] = int32(partition)` to cast from this `int64` to `int32`. Since `ParseInt` was called with `bitSize=32`, it guarantees the value fits into 32 bits, so the cast cannot overflow.
- No new imports are needed; `strconv` is already imported.
- All functionality (reading partition IDs from the `KAFKA_PARTITIONS` environment variable, building a `[]int32`) remains the same; the only change is safer parsing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
